### PR TITLE
Change version number in the manifest file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plugbotapi",
   "description": "An API for creating bots on plug.dj",
-  "version": "1.0",
+  "version": "0.1.0",
   "keywords": ["plug.dj", "plug"],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Node and nom specifically require version numbers to comply with node-semver semantic versioning structure.  "1.0" is an invalid version number and causes npm to fail, even when trying to work with other installed node modules.

I changed the version number to 0.1.0 both to make it semantically valid but also to reflect the fact that the API is incomplete and subject to change.

References: https://www.npmjs.org/doc/misc/semver.html  https://github.com/isaacs/node-semver  
